### PR TITLE
Adapted to changes in core project

### DIFF
--- a/source/Willow-Playground-LiveDocs.package/WPLiveDocumentation.class/class/applicationTitle.st
+++ b/source/Willow-Playground-LiveDocs.package/WPLiveDocumentation.class/class/applicationTitle.st
@@ -1,4 +1,4 @@
-Accessing
+accessing
 applicationTitle
 
 	^ 'Pharo Live Documentation'

--- a/source/Willow-Playground-LiveDocs.package/WPLiveDocumentation.class/class/handlerName.st
+++ b/source/Willow-Playground-LiveDocs.package/WPLiveDocumentation.class/class/handlerName.st
@@ -1,4 +1,4 @@
-Accessing
+accessing
 handlerName
 
 	^ 'live-docs'

--- a/source/Willow-Playground-LiveDocs.package/WPLiveDocumentation.class/class/sessionClass.st
+++ b/source/Willow-Playground-LiveDocs.package/WPLiveDocumentation.class/class/sessionClass.st
@@ -1,4 +1,4 @@
-Accessing
+accessing
 sessionClass
 
 	^ WPLiveDocumentationSession

--- a/source/Willow-Playground-LiveDocs.package/WPLiveDocumentation.class/instance/contentView.st
+++ b/source/Willow-Playground-LiveDocs.package/WPLiveDocumentation.class/instance/contentView.st
@@ -1,4 +1,4 @@
-Accessing
+accessing
 contentView
 
 	^ contentView

--- a/source/Willow-Playground-LiveDocs.package/WPLiveDocumentation.class/instance/jQueryLibrary.st
+++ b/source/Willow-Playground-LiveDocs.package/WPLiveDocumentation.class/instance/jQueryLibrary.st
@@ -1,4 +1,4 @@
-Accessing
+accessing
 jQueryLibrary
 
 	^ (self deploymentMode libraryFor: JQuery3MetadataLibrary) default

--- a/source/Willow-Playground-LiveDocs.package/WPLiveDocumentation.class/instance/newComponentSupplier.st
+++ b/source/Willow-Playground-LiveDocs.package/WPLiveDocumentation.class/instance/newComponentSupplier.st
@@ -1,5 +1,5 @@
-Accessing
-componentSupplier
+accessing
+newComponentSupplier
 
 	^ BootstrapComponentSupplier
 		withBootstrapLibrary: (self deploymentMode libraryFor: Bootstrap3MetadataLibrary) withoutOptionalTheme

--- a/source/Willow-Playground-Smalltalks2017.package/Smalltalks2017Presentation.class/class/applicationTitle.st
+++ b/source/Willow-Playground-Smalltalks2017.package/Smalltalks2017Presentation.class/class/applicationTitle.st
@@ -1,4 +1,4 @@
-Accessing
+accessing
 applicationTitle
 
 	^ 'Willow 101'

--- a/source/Willow-Playground-Smalltalks2017.package/Smalltalks2017Presentation.class/class/handlerName.st
+++ b/source/Willow-Playground-Smalltalks2017.package/Smalltalks2017Presentation.class/class/handlerName.st
@@ -1,4 +1,4 @@
-Accessing
+accessing
 handlerName
 
 	^ 'willow101'

--- a/source/Willow-Playground-Smalltalks2017.package/Smalltalks2017Presentation.class/class/registerAsApplicationUsing..st
+++ b/source/Willow-Playground-Smalltalks2017.package/Smalltalks2017Presentation.class/class/registerAsApplicationUsing..st
@@ -1,4 +1,4 @@
-private-Utility
+private-utility
 registerAsApplicationUsing: deploymentModeClass
 
 	| application |

--- a/source/Willow-Playground-Smalltalks2017.package/Smalltalks2017Presentation.class/class/start.st
+++ b/source/Willow-Playground-Smalltalks2017.package/Smalltalks2017Presentation.class/class/start.st
@@ -1,4 +1,4 @@
-private-Utility
+private-utility
 start
 
 	Smalltalks2017Presentation registerAsDevelopmentApplication.

--- a/source/Willow-Playground-Smalltalks2017.package/Smalltalks2017Presentation.class/class/stop.st
+++ b/source/Willow-Playground-Smalltalks2017.package/Smalltalks2017Presentation.class/class/stop.st
@@ -1,4 +1,4 @@
-private-Utility
+private-utility
 stop
 
 	ZnServer stopDefault.

--- a/source/Willow-Playground-Smalltalks2017.package/Smalltalks2017Presentation.class/instance/newComponentSupplier.st
+++ b/source/Willow-Playground-Smalltalks2017.package/Smalltalks2017Presentation.class/instance/newComponentSupplier.st
@@ -1,8 +1,8 @@
-Accessing
-componentSupplier
+accessing
+newComponentSupplier
 
 	^ BootstrapComponentSupplier
 		withBootstrapLibrary: (self deploymentMode libraryFor: Bootstrap3MetadataLibrary) withoutOptionalTheme
 		selectLibrary: ((self deploymentMode libraryFor: BootstrapSelectLibrary) using: self language)
 		datepickerLibrary: ((self deploymentMode libraryFor: BootstrapDatepickerLibrary) using: self language)
-		typeaheadLibrary: (self deploymentMode libraryFor: BootstrapTypeaheadLibrary) default
+		typeaheadLibrary: (self deploymentMode libraryFor: BootstrapTypeaheadLibrary) new

--- a/source/Willow-Playground-TestRunner.package/WPTestRunner.class/class/applicationTitle.st
+++ b/source/Willow-Playground-TestRunner.package/WPTestRunner.class/class/applicationTitle.st
@@ -1,4 +1,4 @@
-Accessing
+accessing
 applicationTitle
 
 	^ 'Test Runner'

--- a/source/Willow-Playground-TestRunner.package/WPTestRunner.class/class/handlerName.st
+++ b/source/Willow-Playground-TestRunner.package/WPTestRunner.class/class/handlerName.st
@@ -1,4 +1,4 @@
-Accessing
+accessing
 handlerName
 
 	^ 'test-runner-bootstrap3'

--- a/source/Willow-Playground-TestRunner.package/WPTestRunner.class/class/sessionClass.st
+++ b/source/Willow-Playground-TestRunner.package/WPTestRunner.class/class/sessionClass.st
@@ -1,4 +1,4 @@
-Accessing
+accessing
 sessionClass
 
 	^ WPTestRunnerSession

--- a/source/Willow-Playground-TestRunner.package/WPTestRunner.class/instance/contentView.st
+++ b/source/Willow-Playground-TestRunner.package/WPTestRunner.class/instance/contentView.st
@@ -1,4 +1,4 @@
-Accessing
+accessing
 contentView
 
 	^ contentView

--- a/source/Willow-Playground-TestRunner.package/WPTestRunner.class/instance/jQueryLibrary.st
+++ b/source/Willow-Playground-TestRunner.package/WPTestRunner.class/instance/jQueryLibrary.st
@@ -1,4 +1,4 @@
-Accessing
+accessing
 jQueryLibrary
 
 	^ (self deploymentMode libraryFor: JQuery3MetadataLibrary) default

--- a/source/Willow-Playground-TestRunner.package/WPTestRunner.class/instance/newComponentSupplier.st
+++ b/source/Willow-Playground-TestRunner.package/WPTestRunner.class/instance/newComponentSupplier.st
@@ -1,8 +1,8 @@
 accessing
-componentSupplier
+newComponentSupplier
 
 	^ BootstrapComponentSupplier
 		withBootstrapLibrary: (self deploymentMode libraryFor: Bootstrap3MetadataLibrary) withoutOptionalTheme
 		selectLibrary: ((self deploymentMode libraryFor: BootstrapSelectLibrary) using: self language)
 		datepickerLibrary: ((self deploymentMode libraryFor: BootstrapDatepickerLibrary) using: self language)
-		typeaheadLibrary: (self deploymentMode libraryFor: BootstrapTypeaheadLibrary) new
+		typeaheadLibrary: (self deploymentMode libraryFor: BootstrapTypeaheadLibrary) default


### PR DESCRIPTION
- Applications must implement newComponentSupplier, afterwards all access is handled through the session.
- Some category renames to unify capitalization criteria.