### PR TITLE
Remove Unsent `#newComponentSupplier`

### DIFF
--- a/source/Willow-Playground-LiveDocs/WPLiveDocumentation.class.st
+++ b/source/Willow-Playground-LiveDocs/WPLiveDocumentation.class.st
@@ -91,16 +91,6 @@ WPLiveDocumentation >> jQueryLibrary [
 	^ (self deploymentMode libraryFor: JQuery3MetadataLibrary) default
 ]
 
-{ #category : #accessing }
-WPLiveDocumentation >> newComponentSupplier [
-
-	^ BootstrapComponentSupplier
-		withBootstrapLibrary: (self deploymentMode libraryFor: Bootstrap3MetadataLibrary) withoutOptionalTheme
-		selectLibrary: ((self deploymentMode libraryFor: BootstrapSelectLibrary) using: self language)
-		datepickerLibrary: ((self deploymentMode libraryFor: BootstrapDatepickerLibrary) using: self language)
-		typeaheadLibrary: (self deploymentMode libraryFor: BootstrapTypeaheadLibrary) default
-]
-
 { #category : #updating }
 WPLiveDocumentation >> requiredLibraries [
 


### PR DESCRIPTION
Contents were identical to `#componentSupplierForApplication`. Assuming it can be safely removed.